### PR TITLE
removed a bug that doesn't allow user to type currency in lowercase under certain conditions

### DIFF
--- a/Convert.java
+++ b/Convert.java
@@ -46,12 +46,12 @@ public class Convert{
         //Program asks user for the currency they want to exchange and how much of it they want to exchange
         System.out.println("Which currency would you like to exchange?:");
         System.out.println("-USD (United States Dollar)\n-EUR (Euro)\n-JPY (Japanese Yen)\n-GBP (Great Britain Pound)\n-AUD (Australian Dollar)");
-        /*The following lines make the program more user friendly by automatically capitalizing the letters in their currency selection 
+        /*The following lines make the program more user-friendly by automatically capitalizing the letters in their currency selection
         as well as letting them know if they chose an invalid currency*/ 
         String exchangeFrom = input.nextLine().toUpperCase();
         while(!exchangeFrom.equals( "USD") && !exchangeFrom.equals( "EUR") && !exchangeFrom.equals( "JPY") && !exchangeFrom.equals( "GBP") && !exchangeFrom.equals( "AUD")){
             System.out.println("Invalid currency. Please try again.");
-            exchangeFrom = input.nextLine();
+            exchangeFrom = input.nextLine().toUpperCase();
         }
         System.out.println("\nHow much " + exchangeFrom + " would you like to exchange?");
         double amount = input.nextDouble();
@@ -68,7 +68,7 @@ public class Convert{
         String exchangeTo = input.nextLine().toUpperCase();
         while(!exchangeTo.equals( "USD") && !exchangeTo.equals( "EUR") && !exchangeTo.equals( "JPY") && !exchangeTo.equals( "GBP") && !exchangeTo.equals( "AUD")){
             System.out.println("Invalid currency. Please try again.");
-            exchangeTo = input.nextLine();
+            exchangeTo = input.nextLine().toUpperCase();
         }
 
         double finalAmount = (convert(amount, exchangeFrom, exchangeTo));


### PR DESCRIPTION
- **The lowercase issue**
    - When I typed in an invalid currency deliberately (like, "BBB" instead of "JPY" or "USD"), your code did keep telling me: "invalid currency. Please try again." 👍 WHICH IS DOPE! But..
    -  *After typing the invalid currencies*, when I typed 'jpy' or any other valid currencies in lower-case, your code still says "invalid currency." It does work when I type 'JPY' or other valid currencies in upper case, though.
    - eg: try typing, 'bgrei' , then typing 'jpy'. You'll still get invalid currency. Then, type 'JPY' and the code will work.
     - This is because in line 54, you put "exchangeFrom = input.nextLine();" But you should have used "exchangeFrom = 
 input.nextLine().toUpperCase();" instead like you did in line 51.

    - The same issue happened in line 71 btw.  I corrected that too.
    

- **The  'typo'**
    - Also, I just changed a small typo in your comment in line 49 lol, changing 'user friendly' to 'user-friendly' idk bro I use intelliJ 
     - and intelliJ thinks it's a typo AND I COULDN'T STAND TO LOOK AT THAT RED SQUIGGLY TYPO LINE THINGY so I changed it.

btw I'm a uni student new to...well....github and coding and stuff, so I apologize if I act like a moron at times, I'm just not familiar with this environment  T_T